### PR TITLE
fix: remove unnecessary treesitter config call

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -50,7 +50,6 @@ map('t', '', "")
 map('n', '<leader>lf', vim.lsp.buf.format)
 
 vim.lsp.enable({ "lua_ls", "svelte", "tinymist", "emmetls" })
-require('nvim-treesitter.configs').setup({ highlight = { enable = true, }, })
 
 -- colors
 require "vague".setup({ transparent = true })


### PR DESCRIPTION
Using the main branch of the treesitter plugin results in an error when calling `require('nvim-treesitter.configs')`, since .configs is only available on the old master branch:
```
Error in .../.config/nvim/init.lua:
E5113: Lua chunk: .../.config/nvim/init.lua:63: module 'nvim-treesitter.configs' not found:
        no field package.preload['nvim-treesitter.configs']
        no file './nvim-treesitter/configs.lua'
        ...
stack traceback:
        [C]: in function 'require'
        .../.config/nvim/init.lua:63: in main chunk
```
I believe you will get the same error, once you reinstall the treesitter plugin.
Calling require is not even required. see https://github.com/nvim-treesitter/nvim-treesitter/blob/main/doc/nvim-treesitter.txt for further info