### PR TITLE
added prefix indicator

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -7,7 +7,7 @@ set -g status-position top
 set -g status-justify absolute-centre
 set -g status-style "bg=default"
 set -g window-status-current-style "fg=blue bold"
-set -g status-right ""
+set -g status-right "#{?client_prefix,#[fg=blue] (■‿■⌐),#[fg=grey] (•‿• )}"
 set -g status-left "#S"
 
 bind r source-file "~/.config/tmux/tmux.conf"


### PR DESCRIPTION
you can swap out the actual indicator to whatever you would like, memes aside, this makes it helpful when using homerow mods, since my prefix is ctrl + escape, I have to wait for the delay of the mod to register, so this prevents me from doing stuff on accident #39 