### PR TITLE
Added the leader status indicator to STOP category

### DIFF
--- a/scripts/time.sh
+++ b/scripts/time.sh
@@ -22,7 +22,8 @@ tmux set -g status-interval 5
 
 if [[ "$selected" == "STOP" ]]; then
     timew stop
-    tmux set -g status-right ""
+    tmux set -g status-right " "
+    tmux set -g status-right "#{?client_prefix,#[fg=$ACTIVE_COLOR](■‿■⌐),#[fg=grey](•‿• )}"
 else
     timew start "$selected"
     tmux set -g status-right "$selected #(timew | awk '/^ *Total/ {print \$NF}')"


### PR DESCRIPTION
I looked at the time.sh and saw that it was setting the status-right to empty string. but when tmux starts it shows the prefix status indicator so I just added that to the time.sh
 