### PR TITLE
style(tmux.conf): improve tmux status bar display by adding a green box around the currently tracked time in timewarrior.

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -8,7 +8,7 @@ set -g status-justify absolute-centre
 set -g status-style "bg=default"
 set -g window-status-current-style "fg=blue bold"
 set -g status-interval 5
-set -g status-right '#(timew | awk "/^ *Total/ {print \$NF}") #{?client_prefix,#[fg=blue](■‿■⌐),#[fg=grey](•‿• )}'
+set -g status-right '#(timew | awk "/^ *Total/ {print \$NF}") #[bg=green,fg=black,bold]#(timew | awk "/^ *Tracking/ {print \" \" \$NF \" \"}")#[bg=default]#{?client_prefix,#[fg=cyan] (■‿■⌐),#[fg=grey,bg=default] (•‿• )}'
 set -g status-left "#S"
 
 bind r source-file "~/.config/tmux/tmux.conf"


### PR DESCRIPTION
Just does what the title says.

here is a picture of the thing

<img width="338" height="47" alt="image" src="https://github.com/user-attachments/assets/7bd37744-1fb9-4e2f-9a1f-ab65810c5897" />
<img width="330" height="49" alt="image" src="https://github.com/user-attachments/assets/4e42ab7c-31c9-47ef-a712-f4b01e9b78f0" />
