### PR TITLE
docs:fixed the world's most insignificant typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sylvan's Config files 
-A wealth of deepcut knowledge, relatable workflow obsessors, and a great way
+A wealth of deep-cut knowledge, relatable workflow obsessors, and a great way
 to waste all of your time. Be careful with this stuff kids (I'm also a kid). 
 
 Please drop an issue, share your own config, hate on me, roast my code, ask
@@ -7,6 +7,5 @@ why. The biggest way you can support my Youtube efforts is not money (yet), but
 rather sharing and supporting this repo. I want your expertise not your money;
 support me with info, and spread the ergo love. Make this repository famous,
 that would make me very happy and wouldn't cost you anything. A share, a star, 
-a reference to a freind or colleauge are all free, and that's all I ask!
+a reference to a friend or colleague are all free, and that's all I ask!
 Rember, I've never made you listen to a sponsorship haha. Man I hate begging.
-


### PR DESCRIPTION
I left "Rember" because I figured it might be a stylistic choice.