### PR TITLE
Enabled ui-select telescope extension

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -44,7 +44,9 @@ require "marks".setup {
 local default_color = "vague"
 
 require "mason".setup()
-require "telescope".setup({
+
+local telescope = require("telescope")
+telescope.setup({
 	defaults = {
 		preview = { treesitter = false },
 		color_devicons = true,
@@ -59,6 +61,7 @@ require "telescope".setup({
 		}
 	}
 })
+telescope.load_extension("ui-select")
 
 require("actions-preview").setup {
 	backend = { "telescope" },


### PR DESCRIPTION
You haven't even enabled ui-select plugin! Wasted entire line in your minimal configuration. Please, use it or remove it.

Talking about telescope plugins, you may like this one - https://github.com/nvim-telescope/telescope-frecency.nvim