### PR TITLE
Enable Tree-sitter syntax highlighting

### DIFF
--- a/nvim/after/plugin/treesitter.lua
+++ b/nvim/after/plugin/treesitter.lua
@@ -1,0 +1,45 @@
+local ensure_installed = {
+	"c",
+	"markdown",
+	"markdown_inline",
+	"vim",
+	"make",
+	"vimdoc",
+	"query",
+	"bash",
+	"diff",
+	"comment",
+	"editorconfig",
+	"git_config",
+	"git_rebase",
+	"gitattributes",
+	"gitcommit",
+	"gitignore",
+	"javascript",
+	"typescript",
+	"tsx",
+	"jsdoc",
+	"svelte",
+	"yaml",
+	"toml",
+	"json",
+	"lua",
+	"luadoc",
+	"rust",
+	"python",
+	"html",
+	"css",
+	"cpp",
+}
+
+require("nvim-treesitter").install(ensure_installed)
+
+local filetypes = vim.iter(ensure_installed):map(vim.treesitter.language.get_filetypes):flatten():totable()
+
+-- Enable treesitter for all installed languages
+vim.api.nvim_create_autocmd("FileType", {
+	pattern = filetypes,
+	callback = function(ev)
+		vim.treesitter.start(ev.buf)
+	end,
+})

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -269,13 +269,6 @@ vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
 
-vim.api.nvim_create_autocmd("BufWinEnter", {
-	pattern = "*.jsx,*.tsx",
-	group = vim.api.nvim_create_augroup("TS", { clear = true }),
-	callback = function()
-		vim.cmd([[set filetype=typescriptreact]])
-	end
-})
 vim.cmd('colorscheme ' .. default_color)
 
 -- Run gg-repo-sync automatically after saving a PHP file


### PR DESCRIPTION
Hi! I noticed that the nvim-treesitter plugin is installed, but parsers is not installed and syntax highlighting isn't enabled (as far as I know, it's only enabled for Lua by default).

This adds the necessary setup. The file is placed under `after/` so that the `nvim-treesitter` plugin is sourced first. This is important because it sets up ft -> parser aliases for languages where the parser name differs from the filetype (for example, 'tsx' vs 'typescriptreact'). [src](https://github.com/nvim-treesitter/nvim-treesitter/blob/64f4755b9d6ea9008265b09eb79fd91727311682/plugin/filetypes.lua)

I've included a minimal set of languages, but you can easily add more by extending the array and restarting nvim to trigger `.install()`.

Here are some links to my configuration and a few core Neovim maintainers’ configs that you might find useful:

https://github.com/ribru17/.dotfiles/blob/46ce7b17912a3ec9adbe6ac77877c01424b0f220/.config/nvim/lua/rileybruins/settings.lua#L9
https://github.com/echasnovski/nvim/blob/0a566613c169b384ca798917b3379f6feeda39df/plugin/40_plugins.lua#L18
https://github.com/skewb1k/dotfiles/blob/d33e08f7f82fae33d2a9223217447ece4255aca6/nvim/.config/nvim/after/plugin/treesitter.lua

Fixes #234